### PR TITLE
남은 시간을 카운팅하는 훅 생성

### DIFF
--- a/client/src/components/DetailPage/AuctionStatus/AuctionStatus.tsx
+++ b/client/src/components/DetailPage/AuctionStatus/AuctionStatus.tsx
@@ -1,5 +1,6 @@
 import { ProductStatus } from '../../_common/ProductStatus/ProductStatus';
 import { AUCTION_STATUS } from '../../../constants/constants';
+import { useGetTimeRemain } from '../../../hooks/useGetTimeRemain';
 
 type AuctionStatusProps = {
   finishedAt: string;
@@ -7,12 +8,14 @@ type AuctionStatusProps = {
 };
 
 export const AuctionStatus = ({ finishedAt, statusId }: AuctionStatusProps) => {
+  // 종료 시간을 전달하면, 현재 시간으로 남은 시간을 시:분:초 형태의 string으로 리턴
+  const { timeRemain } = useGetTimeRemain(finishedAt);
+
   return (
     <section className="flex h-9 w-full justify-between items-center px-2 bg-white">
       <article className="space-x-2">
         <span>남은 시간</span>
-        {/* TODO: 남은 시간 카운트하는 함수 만들어서 적용 */}
-        <span className="text-main-orange">{finishedAt}</span>
+        <span className="text-main-orange">{timeRemain}</span>
       </article>
       {/* TODO: 로그인 여부, 판매자 / 입찰자 여부 판단하여 조건부 렌더링 */}
       <ProductStatus>{AUCTION_STATUS[statusId]}</ProductStatus>

--- a/client/src/components/SearchPage/TopSearchKeywords/TopSearchKeywords.tsx
+++ b/client/src/components/SearchPage/TopSearchKeywords/TopSearchKeywords.tsx
@@ -10,8 +10,8 @@ export const TopSearchKeywords = ({ keywords }: TopSearchKeywordsProps) => {
       <h2 className="text-lg font-bold mb-3">인기 검색어</h2>
       <article className="flex flex-col space-y-2">
         {keywords.map((keyword, idx) => (
-          <Link to={`/search/0_${keyword}`}>
-            <div key={keyword} className="flex cursor-pointer">
+          <Link to={`/search/0_${keyword}`} key={keyword}>
+            <div className="flex cursor-pointer">
               <span className="block w-9">{idx + 1}</span>
               <span>{keyword}</span>
             </div>

--- a/client/src/hooks/useGetTimeRemain.ts
+++ b/client/src/hooks/useGetTimeRemain.ts
@@ -12,17 +12,10 @@ export const useGetTimeRemain = (finishedAt: string) => {
   const seconds = Math.floor((timeDiff / 1000) % 60);
 
   // 현재 시간을 1초마다 업데이트
-  useInterval(
-    () => {
-      setRealTime(new Date());
-    },
-    1000,
-    timeDiff >= 0
-  );
-
   // 업데이트된 시간을 바탕으로 시,분,초 업데이트
   useInterval(
     () => {
+      setRealTime(new Date());
       setTimeRemain(`${hours} : ${minutes} : ${seconds}`);
     },
     1000,

--- a/client/src/hooks/useGetTimeRemain.ts
+++ b/client/src/hooks/useGetTimeRemain.ts
@@ -1,0 +1,33 @@
+import { useState } from 'react';
+import { useInterval } from './useInterval';
+
+export const useGetTimeRemain = (finishedAt: string) => {
+  const [realTime, setRealTime] = useState(new Date());
+  const [timeRemain, setTimeRemain] = useState('');
+  const finishTime = new Date(finishedAt);
+  const timeDiff = +finishTime - +realTime;
+
+  const hours = Math.floor((timeDiff / (1000 * 60 * 60)) % 24);
+  const minutes = Math.floor((timeDiff / (1000 * 60)) % 60);
+  const seconds = Math.floor((timeDiff / 1000) % 60);
+
+  // 현재 시간을 1초마다 업데이트
+  useInterval(
+    () => {
+      setRealTime(new Date());
+    },
+    1000,
+    timeDiff >= 0
+  );
+
+  // 업데이트된 시간을 바탕으로 시,분,초 업데이트
+  useInterval(
+    () => {
+      setTimeRemain(`${hours} : ${minutes} : ${seconds}`);
+    },
+    1000,
+    timeDiff >= 0
+  );
+
+  return { timeRemain };
+};

--- a/client/src/hooks/useInterval.ts
+++ b/client/src/hooks/useInterval.ts
@@ -27,6 +27,4 @@ export const useInterval = (callback: () => void, delay: number, shouldContinue?
     // eslint-disable-next-line
     else return () => null;
   }, [delay]);
-
-  // 주입된 종료 조건에 따라 interval을 종료한다.
 };

--- a/client/src/hooks/useInterval.ts
+++ b/client/src/hooks/useInterval.ts
@@ -1,0 +1,32 @@
+import { useEffect, useRef } from 'react';
+
+// shoudContinue 는 setInterval의 종료시점을 의미합니다.
+export const useInterval = (callback: () => void, delay: number, shouldContinue?: boolean) => {
+  // ref 는 함수가 재실행되어도 값을 기억하는 객체입니다.
+  const savedCallback = useRef<() => void>();
+
+  // 콜백함수를 ref 에 저장합니다.
+  useEffect(() => {
+    savedCallback.current = callback;
+  });
+
+  useEffect(() => {
+    if (shouldContinue) {
+      const tick = () => {
+        // 콜백함수가 있는 경우 이를 실행하는 함수입니다.
+        if (savedCallback.current) {
+          savedCallback.current();
+        }
+      };
+
+      // 매 delay마다 interval을 실행합니다.
+      // useEffect 훅이 종료되면 인터벌을 종료합니다.
+      const id = setInterval(tick, delay);
+      return () => clearInterval(id);
+    }
+    // eslint-disable-next-line
+    else return () => null;
+  }, [delay]);
+
+  // 주입된 종료 조건에 따라 interval을 종료한다.
+};

--- a/client/src/mock/productDetail.ts
+++ b/client/src/mock/productDetail.ts
@@ -20,7 +20,7 @@ export const productDetail = {
   currentPrice: '120,000',
   statusId: 0,
   createdAt: '2023-02-06T01:02:00',
-  finishedAt: '2023-02-07T01:02:00',
+  finishedAt: '2023-02-10T20:00:00',
   viewCount: '30',
   bidCount: '3',
   history: [100, 200, 300],


### PR DESCRIPTION
![auction-7](https://user-images.githubusercontent.com/89173923/218035587-5cf8addb-9bdc-490a-99f5-c6b88bc85c6f.gif)
* 종료 시간을 기준으로 남은 시간을 리턴해주는 훅을 생성했습니다.
* 리액트에서 일반적인 방식으로 interval을 할 경우, state가 계속 업데이트되어 무한 렌더링 되는 현상이 일어납니다.
* 이를 방지하기 위해 useInterval 훅을 생성했습니다. (참고 : https://overreacted.io/making-setinterval-declarative-with-react-hooks/ )
* 어디에서든 재사용 할 수 있도록 useGetTimeRemain훅을 만들었습니다. 
* 종료시간을 인자로 넘겨주면 현재 시간을 문자열로 리턴합니다.
* 리액트 state에 담겨있기 때문에 그대로 사용하시면 자동으로 리렌더링 됩니다. 