### PR TITLE
차트 실시간 데이터 렌더링, 하단 탭 바 로그인 페이지 렌더링 수정

### DIFF
--- a/client/src/components/DetailPage/Chart/Chart.tsx
+++ b/client/src/components/DetailPage/Chart/Chart.tsx
@@ -1,51 +1,54 @@
 import { Chart as ChartJS, CategoryScale, LinearScale, LineElement, PointElement, Title, Tooltip } from 'chart.js';
 import { Line } from 'react-chartjs-2';
-import { useEffect, useState } from 'react';
+import { useMemo } from 'react';
 import { ProductDetailRealtimeResp } from '../../../types/product.type';
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Title);
 
-export const options = {
-  responsive: true,
-  plugins: {
-    legend: {
-      position: 'top' as const,
-    },
-    title: {
-      display: true,
-      text: '입찰가 추이',
-    },
-  },
-};
-
 type ChartProps = {
-  initData: number[];
   realTimeData: Partial<ProductDetailRealtimeResp>;
 };
 
-export const Chart = ({ realTimeData, initData }: ChartProps) => {
+export const Chart = ({ realTimeData }: ChartProps) => {
   const { history } = realTimeData;
-  const [data, setData] = useState(initData);
-  const [chartData, setChartData] = useState({
-    labels: data,
-    datasets: [
-      {
-        label: '입찰가 추이',
-        data,
-        borderColor: '#F0A500',
-        backgroundColor: '#F0A500',
+
+  // 차트 데이터는 data 상태가 업데이트 될 때마다 새롭게 계산됩니다. (다시 계산되어 화면에 렌더링합니다!)
+  const chartData = useMemo(
+    () => ({
+      labels: history,
+      datasets: [
+        {
+          label: '입찰가 추이',
+          data: history,
+          borderColor: '#F0A500',
+          backgroundColor: '#F0A500',
+        },
+      ],
+    }),
+    [history]
+  );
+
+  // 옵션값도 메모이제이션합니다.
+  const options = useMemo(
+    () => ({
+      responsive: true,
+      plugins: {
+        legend: {
+          position: 'top' as const,
+        },
+        title: {
+          display: true,
+          text: '입찰가 추이',
+        },
       },
-    ],
-  });
+    }),
+    []
+  );
 
-  useEffect(() => {
-    if (history) setData(history);
-  }, [history]);
-
-  // FIXME: 반응형으로 화면 크기 바뀔 때 너비가 달라지지 않는 현상 있음.
-  // FIXME: 컴포넌트 마운트, 언마운트시에 제대로 렌더링되도록 useEffect 적용 필요해보임.
+  // TODO: 차트 반응형 적용
   return (
-    <section className="flex flex-col space-y-2 w-full justify-center">
+    // 이전 차트와 다른 차트 렌더링 위해 key 값 지정
+    <section key={realTimeData.boardId} className="flex flex-col space-y-2 w-full justify-center relative">
       <Line options={options} data={chartData} className="h-full bg-white px-2 w-full" />
     </section>
   );

--- a/client/src/components/_common/TabBar/TabBar.tsx
+++ b/client/src/components/_common/TabBar/TabBar.tsx
@@ -1,12 +1,21 @@
 import { Link, useLocation } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
+import { loginStateAtom } from '../../../atoms/user';
 
 const TAB_TITLE = ['', 'category', 'search', 'postProduct', 'my'];
 
 const TabIcon = ({ children, idx }) => {
   const location = useLocation();
+  const loginState = useRecoilValue(loginStateAtom);
+
+  const getDestination = (endpoint: string) => {
+    if (!loginState && endpoint === 'my') return 'login';
+    return endpoint;
+  };
+
   return (
     <Link
-      to={`/${TAB_TITLE[idx]}`}
+      to={`/${getDestination(TAB_TITLE[idx])}`}
       className={`text-base flex flex-col justify-center items-center cursor-pointer ${
         location.pathname === `/${TAB_TITLE[idx]}` && 'text-main-red'
       }`}>

--- a/client/src/pages/DetailPage.tsx
+++ b/client/src/pages/DetailPage.tsx
@@ -18,7 +18,8 @@ export const DetailPage = () => {
   const { response, sendBid } = useWebsocket(`/sub/board-id/${boardId}`);
 
   const { isLoading, error, data } = useQuery(
-    'productDetail',
+    // 각 상품 데이터가 unique한 key 값을 갖도록 배열로 정했습니다.
+    ['productDetail', boardId],
     async () => {
       const res = await productDetailAPI.get(boardId);
       return res.data;
@@ -52,7 +53,7 @@ export const DetailPage = () => {
         <BidInformation reatTimeData={response} sendBid={sendBid} />
 
         <article className="py-8 bg-white px-2">{description}</article>
-        <Chart realTimeData={response} initData={history} />
+        <Chart realTimeData={response} />
       </section>
       <TabBar />
     </main>


### PR DESCRIPTION
![daily-0224-1](https://user-images.githubusercontent.com/89173923/221099209-4aa37128-1b75-482e-aa57-33fb779ec364.gif)
* useMemo를 활용해 실시간 데이터 변동시에 값을 새롭게 계산하도록 수정하여 반영했습니다.
* 하단 탭 바에서 로그인 여부를 확인해 마이페이지 혹은 로그인 페이지로 이동합니다~