### PR TITLE
fix: 서버 재실행시 가격 반영없이 삭제하는 버그 수정

### DIFF
--- a/server/src/main/java/com/project/dailyAuction/cache/CacheEvent.java
+++ b/server/src/main/java/com/project/dailyAuction/cache/CacheEvent.java
@@ -18,6 +18,8 @@ public class CacheEvent {
     public void initCache(){
         cacheProcessor.updateViewCntToMySql();
         cacheProcessor.updateBiddingToMySql();
+        cacheProcessor.updateTopKeywordToMySql();
+        cacheProcessor.updateBoardPriceToMySql();
         cacheProcessor.deleteRedisPerHour();
         cacheProcessor.updateBoardStatusToMySql();
         log.info("**Log : Update To DB - Init");


### PR DESCRIPTION
DB에 반영 전에 레디스에서 가격정보를 삭제해버려서 코드 수정했습니다.