### PR TITLE
SSE 알림 수신 기능 구현

### DIFF
--- a/client/src/components/ChargePage/Charge/useCharge.ts
+++ b/client/src/components/ChargePage/Charge/useCharge.ts
@@ -23,7 +23,7 @@ export const useCharge = ({ coinValue, setCoinValue, setModalOpen, setAdviceText
     },
     {
       onSuccess: (res) => {
-        setUserInfo((prev) => ({ ...prev, coin: String(res) }));
+        setUserInfo((prev) => ({ ...prev, coin: res }));
         setModalOpen(true);
       },
       onError: (error) => {

--- a/client/src/components/DetailPage/BidInformation/BidModal.tsx
+++ b/client/src/components/DetailPage/BidInformation/BidModal.tsx
@@ -4,6 +4,7 @@ import { myInfoAPI } from '../../../api/myPageAPI';
 import { userInfoAtom } from '../../../atoms/user';
 import { blockInvalidChar } from '../../../utils/blockInvalidChar';
 import { useBidInfoModal } from './useBidInfoModal';
+import { accessTokenAtom } from '../../../atoms/token';
 
 type BidModalProps = {
   currentPrice: number;
@@ -21,13 +22,15 @@ export const BidModal = ({ handleClose, currentPrice, sendBid }: BidModalProps) 
   const { coin: myCoin } = useRecoilValue(userInfoAtom);
 
   // TODO: 입찰 성공 후 코인 업데이트 요청하기
+  const accessToken = useRecoilValue(accessTokenAtom);
+
   useEffect(() => {
-    const token = localStorage.getItem('access');
+    const get = async () => {
+      const res = await myInfoAPI.get(accessToken);
+      return res;
+    };
     try {
-      (async () => {
-        const res = await myInfoAPI.get(token);
-        console.log(res.data);
-      })();
+      const res = get();
     } catch (err) {
       console.error(err);
     }

--- a/client/src/components/DetailPage/BidInformation/useBidInfoModal.ts
+++ b/client/src/components/DetailPage/BidInformation/useBidInfoModal.ts
@@ -1,5 +1,7 @@
 import { SetStateAction } from 'react';
-import { useRecoilValue } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
+import { myInfoAPI } from '../../../api/myPageAPI';
+import { accessTokenAtom } from '../../../atoms/token';
 import { userInfoAtom } from '../../../atoms/user';
 
 type UseBidInfoModalFactor = {
@@ -9,7 +11,18 @@ type UseBidInfoModalFactor = {
 };
 
 export const useBidInfoModal = ({ bidValue, setBidValue, setValidationMsg }: UseBidInfoModalFactor) => {
-  const { coin: myCoin } = useRecoilValue(userInfoAtom);
+  const [{ coin: myCoin }, setCoin] = useRecoilState(userInfoAtom);
+  const accessToken = useRecoilValue(accessTokenAtom);
+
+  // 코인 잔액 업데이트 핸들러
+  const handleUpdateCoin = async () => {
+    try {
+      const { coin } = await myInfoAPI.get(accessToken);
+      setCoin((prev) => ({ ...prev, coin }));
+    } catch (err) {
+      console.error(err);
+    }
+  };
 
   // bidValue 변경 핸들러
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/client/src/components/_common/Header/MainHeader/MainHeader.tsx
+++ b/client/src/components/_common/Header/MainHeader/MainHeader.tsx
@@ -1,25 +1,20 @@
-import { EventSourcePolyfill } from 'event-source-polyfill';
-import { useEffect } from 'react';
 import { Link } from 'react-router-dom';
+import { useEffect } from 'react';
 import { useRecoilValue } from 'recoil';
-import { accessTokenAtom } from '../../../../atoms/token';
+import { loginStateAtom } from '../../../../atoms/user';
+import { useSSE } from '../../../../hooks/useSSE';
 
 export const MainHeader = ({ children }) => {
-  // sse 이벤트 수신
-  const accessToken = useRecoilValue(accessTokenAtom);
+  const loginState = useRecoilValue(loginStateAtom);
+  const { fetchSSE } = useSSE();
 
+  // 로그인이 되어있는 경우에만 알림을 수신하도록 SSE를 연결합니다.
   useEffect(() => {
-    const eventSource = new EventSourcePolyfill(`${process.env.REACT_APP_URL}/subscribe`, {
-      headers: { Authorization: accessToken },
-    });
+    if (loginState) {
+      fetchSSE();
+    }
 
-    eventSource.onmessage = (event) => {
-      console.log(event.data);
-    };
-
-    return () => {
-      eventSource.close();
-    };
+    return () => null;
   }, []);
 
   return (

--- a/client/src/components/_common/Header/MainHeader/MainHeader.tsx
+++ b/client/src/components/_common/Header/MainHeader/MainHeader.tsx
@@ -6,16 +6,17 @@ import { useSSE } from '../../../../hooks/useSSE';
 
 export const MainHeader = ({ children }) => {
   const loginState = useRecoilValue(loginStateAtom);
-  const { fetchSSE } = useSSE();
+  const { fetchSSE, eventSource } = useSSE();
 
   // 로그인이 되어있는 경우에만 알림을 수신하도록 SSE를 연결합니다.
+  // TODO: 어떤 컴포넌트에서든 연결을 유지하도록 변경할 것
   useEffect(() => {
     if (loginState) {
       fetchSSE();
     }
 
-    return () => null;
-  }, []);
+    return () => eventSource.current?.close();
+  }, [eventSource]);
 
   return (
     <header className="h-14 w-full sticky bg-main-brown py-3">

--- a/client/src/hooks/useSSE.ts
+++ b/client/src/hooks/useSSE.ts
@@ -1,0 +1,34 @@
+import { EventSourcePolyfill, NativeEventSource } from 'event-source-polyfill';
+import { useCallback, useEffect, useRef } from 'react';
+import { useRecoilValue } from 'recoil';
+import { accessTokenAtom } from '../atoms/token';
+
+export const useSSE = () => {
+  const accessToken = useRecoilValue(accessTokenAtom);
+  const eventSource = useRef<EventSourcePolyfill | EventSource>();
+
+  // sse 연결 함수
+  const fetchSSE = useCallback(() => {
+    const EventSource = EventSourcePolyfill || NativeEventSource;
+
+    eventSource.current = new EventSource(`${process.env.REACT_APP_URL}/subscribe`, {
+      headers: {
+        Authorization: accessToken,
+      },
+      heartbeatTimeout: 30000,
+    });
+
+    eventSource.current.onmessage = (event) => {
+      console.log(event.data);
+    };
+
+    eventSource.current.onerror = (event) => {
+      console.error(event);
+    };
+  }, [accessToken]);
+
+  // TODO: SSE 알림 수신시 알림 데이터 저장
+
+  // 조건에 따라 sse 연결 함수를 실행하도록 fetchSSE 그리고 eventSource 객체를 리턴합니다.
+  return { fetchSSE, eventSource };
+};

--- a/client/src/hooks/useSSE.ts
+++ b/client/src/hooks/useSSE.ts
@@ -24,8 +24,9 @@ export const useSSE = () => {
 
     eventSource.current.onerror = (event) => {
       console.error(event);
+      eventSource.current.close();
     };
-  }, [accessToken]);
+  }, []);
 
   // TODO: SSE 알림 수신시 알림 데이터 저장
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/89173923/221796887-39f24a89-b0d7-4aa3-885c-fafe4095af6b.png)

* SSE 연결로 알림 수신 기능 구현하였습니다.
* 매 30초마다 서버와 클라이언트 모두 Timeout 되고 재 연결하여 연결을 유지합니다. (클라이언트에서 연결을 끊는다고 하여 서버의 Emitter가 사라지지 않기 때문에 타임아웃 시간을 동일하게 맞췄습니다.)

### 수정될 내용
* 현재는 메인 컴포넌트가 렌더링 될 때마다 SSE를 연결하도록 하였지만, 추후 로그인만 이루어지면 어떤 컴포넌트에서도 접근할 수 있도록 변경할 예정입니다.
* 이유는 특정 페이지에 접속했을 때에 일어나는 이벤트만 수신하는 것보다는, 알림을 확인하기 이전에 일어나는 모든 이벤트를 다 수신했다가 보는게 더 자연스럽기 때문입니다.