### PR TITLE
게시글 상세페이지 입찰 후 데이터 업데이트 수정

### DIFF
--- a/client/src/api/boardsAPI.ts
+++ b/client/src/api/boardsAPI.ts
@@ -4,12 +4,17 @@ import { httpClient } from '../utils/httpClient';
 export const productDetailAPI = {
   url: `/boards`,
 
-  get: (path: string, token: string) =>
-    httpClient.get<ProductDetailResp>(`${productDetailAPI.url}/${path}`, {
-      headers: {
-        Authorization: token,
-      },
-    }),
+  get: (path: string, token: string) => {
+    const option = token
+      ? {
+          headers: {
+            Authorization: token,
+          },
+        }
+      : null;
+
+    return httpClient.get<ProductDetailResp>(`${productDetailAPI.url}/${path}`, option);
+  },
 
   postBid: (path: string, newPrice: number) => httpClient.post(`${productDetailAPI.url}/${path}/bidding`, { newPrice }),
 

--- a/client/src/api/boardsAPI.ts
+++ b/client/src/api/boardsAPI.ts
@@ -4,7 +4,12 @@ import { httpClient } from '../utils/httpClient';
 export const productDetailAPI = {
   url: `/boards`,
 
-  get: (path: string) => httpClient.get<ProductDetailResp>(`${productDetailAPI.url}/${path}`),
+  get: (path: string, token: string) =>
+    httpClient.get<ProductDetailResp>(`${productDetailAPI.url}/${path}`, {
+      headers: {
+        Authorization: token,
+      },
+    }),
 
   postBid: (path: string, newPrice: number) => httpClient.post(`${productDetailAPI.url}/${path}/bidding`, { newPrice }),
 

--- a/client/src/components/DetailPage/AuctionStatus/useAuctionStatus.ts
+++ b/client/src/components/DetailPage/AuctionStatus/useAuctionStatus.ts
@@ -1,26 +1,13 @@
-import { useQuery } from 'react-query';
 import { useLocation } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
-import { productDetailAPI } from '../../../api/boardsAPI';
 import { userInfoAtom } from '../../../atoms/user';
+import { useGetProductDetail } from '../../../hooks/useGetProductDetail';
 
 export const useAuctionStatus = () => {
   // 게시글 데이터 요청 로직
   const boardId = useLocation().pathname.split('/')[2];
 
-  const { data } = useQuery(
-    'productDetail',
-    async () => {
-      const res = await productDetailAPI.get(boardId);
-      return res.data;
-    },
-    {
-      onError: (e) => console.error(e),
-      refetchOnMount: true,
-    }
-  );
-
-  // data가 undefined, null인 경우 TypeError 발생, 아닐 경우에만 분해되도록 함.
+  const { data } = useGetProductDetail(boardId);
   const { finishedAt, statusId, authorId, bidderId } = data || {};
   const { memberId } = useRecoilValue(userInfoAtom);
 

--- a/client/src/components/DetailPage/BidInformation/BidInformation.tsx
+++ b/client/src/components/DetailPage/BidInformation/BidInformation.tsx
@@ -1,14 +1,12 @@
 import { useState } from 'react';
 import { useLocation } from 'react-router-dom';
-import { useQuery } from 'react-query';
 import { useRecoilValue } from 'recoil';
 import { userInfoAtom } from '../../../atoms/user';
 import { useHandleIsLogin } from '../../../hooks/useHandleIsLogin';
 import { useBidInformation } from './useBidInformation';
-
-import { productDetailAPI } from '../../../api/boardsAPI';
 import { ProductDetailRealtimeResp } from '../../../types/product.type';
 import { BidModal } from './BidModal';
+import { useGetProductDetail } from '../../../hooks/useGetProductDetail';
 
 type BidInformationProps = {
   reatTimeData: Partial<ProductDetailRealtimeResp>;
@@ -22,26 +20,15 @@ export const BidInformation = ({ reatTimeData, sendBid }: BidInformationProps) =
     setModalOpen(true);
   };
 
-  const { handleIsLogin } = useHandleIsLogin();
-  const { handleClickRePost, handleDeleteProduct } = useBidInformation();
-
-  const userInfo = useRecoilValue(userInfoAtom);
   const boardId = useLocation().pathname.split('/')[2];
 
-  // fetch data
-  const { isLoading, error, data } = useQuery(
-    'productDetail',
-    async () => {
-      const res = await productDetailAPI.get(boardId);
-      return res.data;
-    },
-    {
-      onError: (e) => console.error(e),
-    }
-  );
+  const { handleIsLogin } = useHandleIsLogin();
+  const { handleClickRePost, handleDeleteProduct } = useBidInformation();
+  const { memberId } = useRecoilValue(userInfoAtom);
+  const { data, isLoading, error } = useGetProductDetail(boardId);
 
   // 일반 경매 정보 데이터
-  const { statusId, startingPrice, myPrice = null, authorId } = data || {};
+  const { statusId, startingPrice, myPrice, authorId, bidderId } = data || {};
 
   // 실시간 경매 정보 데이터
   const { currentPrice, bidCount } = reatTimeData;
@@ -54,12 +41,15 @@ export const BidInformation = ({ reatTimeData, sendBid }: BidInformationProps) =
       <section className="flex w-full justify-center bg-white px-2 py-3 space-y-4 flex-col">
         <article className="flex items-center space-x-2">
           <span className="text-lg font-bold text-main-orange">{currentPrice?.toLocaleString()} coin</span>
-          <span className="text-sm">{myPrice ? `내 입찰가 : ${myPrice}` : `시작가 : ${startingPrice}`}</span>
+          <span className="text-sm">
+            {myPrice ? `내 입찰가 : ${myPrice.toLocaleString()}` : `시작가 : ${startingPrice.toLocaleString()}`}
+          </span>
         </article>
         <article className="flex w-full justify-between items-center">
           <span className="text-sm">입찰 횟수 : {bidCount}</span>
-          {/* 진행중이면서  */}
-          {statusId === 1 && authorId !== userInfo.memberId && (
+
+          {/* 진행중, 내 경매 아이템 X, 이미 입찰한 아이템 X */}
+          {statusId === 1 && authorId !== memberId && bidderId !== memberId && (
             <button
               type="submit"
               className="red-btn"
@@ -69,7 +59,9 @@ export const BidInformation = ({ reatTimeData, sendBid }: BidInformationProps) =
               입찰
             </button>
           )}
-          {statusId === 3 && authorId === userInfo.memberId && (
+
+          {/* 종료, 내가 등록한 아이템 */}
+          {statusId === 3 && authorId === memberId && (
             <article className="flex items-center space-x-2">
               <button type="submit" className="red-btn" onClick={() => handleClickRePost(boardId)}>
                 재등록

--- a/client/src/components/DetailPage/BidInformation/BidModal.tsx
+++ b/client/src/components/DetailPage/BidInformation/BidModal.tsx
@@ -1,10 +1,8 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useRecoilValue } from 'recoil';
-import { myInfoAPI } from '../../../api/myPageAPI';
 import { userInfoAtom } from '../../../atoms/user';
 import { blockInvalidChar } from '../../../utils/blockInvalidChar';
 import { useBidInfoModal } from './useBidInfoModal';
-import { accessTokenAtom } from '../../../atoms/token';
 
 type BidModalProps = {
   currentPrice: number;
@@ -12,29 +10,13 @@ type BidModalProps = {
   handleClose: () => void;
 };
 
-// 입찰 모달
 export const BidModal = ({ handleClose, currentPrice, sendBid }: BidModalProps) => {
   const [bidValue, setBidValue] = useState('');
-  const [validationMsg, setValidationMsg] = useState('');
+  const [validationMsg, setValidationMsg] = useState('1000coin 단위로 입력해주세요!');
 
   const { handleClickBid, handleChange } = useBidInfoModal({ bidValue, setBidValue, setValidationMsg });
 
   const { coin: myCoin } = useRecoilValue(userInfoAtom);
-
-  // TODO: 입찰 성공 후 코인 업데이트 요청하기
-  const accessToken = useRecoilValue(accessTokenAtom);
-
-  useEffect(() => {
-    const get = async () => {
-      const res = await myInfoAPI.get(accessToken);
-      return res;
-    };
-    try {
-      const res = get();
-    } catch (err) {
-      console.error(err);
-    }
-  }, []);
 
   return (
     <section className="bg-modal z-10">

--- a/client/src/components/DetailPage/BidInformation/useBidInfoModal.ts
+++ b/client/src/components/DetailPage/BidInformation/useBidInfoModal.ts
@@ -52,6 +52,7 @@ export const useBidInfoModal = ({ bidValue, setBidValue, setValidationMsg }: Use
 
         // 웹소켓을 통한 send
         sendBid(bidValuePer1000);
+        setBidValue('');
         // await로 코인이 업데이트 될 때까지 대기
         // 입찰을 완료한 후 곧바로 코인을 업데이트!
         await handleUpdateCoin();

--- a/client/src/components/DetailPage/BidInformation/useBidInfoModal.ts
+++ b/client/src/components/DetailPage/BidInformation/useBidInfoModal.ts
@@ -3,6 +3,7 @@ import { useRecoilState, useRecoilValue } from 'recoil';
 import { myInfoAPI } from '../../../api/myPageAPI';
 import { accessTokenAtom } from '../../../atoms/token';
 import { userInfoAtom } from '../../../atoms/user';
+import { useCoinCalc } from '../../../hooks/useCoinCalc';
 
 type UseBidInfoModalFactor = {
   bidValue?: string;
@@ -36,22 +37,24 @@ export const useBidInfoModal = ({ bidValue, setBidValue, setValidationMsg }: Use
   };
 
   // 구매자가 입찰시 사용되는 핸들러
-  const handleClickBid = (currentPrice: number, sendBid: (price: number) => void) => {
-    // 현재 가진 코인보다 입력한 코인이 더 많을 경우
+  const handleClickBid = async (currentPrice: number, sendBid: (price: number) => void) => {
     if (+bidValue > +myCoin) {
       setValidationMsg('보유한 코인이 부족합니다.');
-    }
-    // 현재 경매가보다 입력한 코인이 더 적은 경우
-    else if (+bidValue <= +currentPrice) {
+    } else if (+bidValue <= +currentPrice) {
       setValidationMsg('현재 경매가보다 높은 가격을 입력해주세요.');
-    }
-    // 모든 조건을 통과한 경우
-    else {
+    } else {
+      const bidValuePer1000 = useCoinCalc(bidValue);
+      setBidValue(String(bidValuePer1000));
+
       // eslint-disable-next-line no-restricted-globals, no-alert, no-lonely-if
-      if (confirm('입찰 하시겠습니까?')) {
+      if (confirm(`${bidValuePer1000}coin으로 입찰 하시겠습니까?`)) {
         setValidationMsg('입찰하였습니다!');
-        // useWebsocket으로 부터 온 sendBid 함수로 웹소켓을 통한 send
-        sendBid(+bidValue);
+
+        // 웹소켓을 통한 send
+        sendBid(bidValuePer1000);
+        // await로 코인이 업데이트 될 때까지 대기
+        // 입찰을 완료한 후 곧바로 코인을 업데이트!
+        await handleUpdateCoin();
       }
     }
   };

--- a/client/src/hooks/useGetProductDetail.ts
+++ b/client/src/hooks/useGetProductDetail.ts
@@ -1,0 +1,23 @@
+import { useQuery } from 'react-query';
+import { useRecoilValue } from 'recoil';
+import { productDetailAPI } from '../api/boardsAPI';
+import { accessTokenAtom } from '../atoms/token';
+
+export const useGetProductDetail = (boardId: string) => {
+  const accessToken = useRecoilValue(accessTokenAtom);
+
+  const { isLoading, error, data } = useQuery(
+    // 각 상품 데이터가 unique한 key 값을 갖도록 배열로 정했습니다.
+    ['productDetail', boardId],
+    async () => {
+      const res = await productDetailAPI.get(boardId, accessToken);
+      return res.data;
+    },
+    {
+      refetchOnMount: true,
+      onError: (e) => console.error(e),
+    }
+  );
+
+  return { data, isLoading, error };
+};

--- a/client/src/hooks/useWebsocket.ts
+++ b/client/src/hooks/useWebsocket.ts
@@ -42,6 +42,7 @@ export const useWebsocket = (subEndpoint: string) => {
     };
 
     // FIXME: 서버에서 전송되는 에러 로그 찍을 수 있도록 수정
+    // HTTP 응답값으로 에러 데이터를 보내주고 계시기 때문에 받을 수 있도록 해보기.
     client.current.onStompError = (frame) => {
       console.log('Broker reported error: ' + frame.headers.message);
       console.log('Additional details: ' + frame.body);


### PR DESCRIPTION
![daily-0301-1](https://user-images.githubusercontent.com/89173923/222074742-3b0e582d-d6d1-4027-a8ee-396ecda32623.gif)

* 입찰 이후 코인 잔액 업데이트 하도록 수정했습니다.
* 게시글 상세페이지에서 useQuery를 사용하는 부분 중복 코드가 많아 커스텀 훅으로 분리했습니다.
* 실시간 데이터가 업데이트 될 때마다 게시글 데이터가 refetch되면서 화면을 업데이트합니다.
* 게시글 상세페이지에서도 토큰이 있는 경우 토큰을 함께 전송하도록 코드 수정하였습니다.