### PR TITLE
SSE 실시간 알림 수신 및 렌더링

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -2,6 +2,7 @@ import { RecoilRoot } from 'recoil';
 import { useState } from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { Router } from './router/Router';
+import { SSE } from './components/_common/SSE/SSE';
 
 declare module 'react-query/types/react/QueryClientProvider' {
   interface QueryClientProviderProps {
@@ -26,6 +27,7 @@ export const App = () => {
     <div className="flex items-center justify-center w-screen h-screen bg-background-desktop">
       <RecoilRoot>
         <QueryClientProvider client={queryClient}>
+          <SSE />
           <Router />
         </QueryClientProvider>
       </RecoilRoot>

--- a/client/src/components/NotificationPage/Notification/Notification.tsx
+++ b/client/src/components/NotificationPage/Notification/Notification.tsx
@@ -1,23 +1,16 @@
 import { Link } from 'react-router-dom';
 import { NOTIFICATION_STATUS, NOTIFICATION_STATUS_MSG } from '../../../constants/constants';
 import { getShortString } from '../../../utils/getShortString';
-import { useNotification } from './useNotification';
+import { useNotification } from '../../../hooks/useNotification';
+import { NotificationResp } from '../../../types/notice.type';
 
-type NotificationProps = {
-  noticeId: number;
-  boardId: number;
-  boardTitle: string;
-  image: string;
-  status: number;
-  contact?: string;
-};
-
-export const Notification = ({ noticeId, boardId, boardTitle, image, status, contact }: NotificationProps) => {
+export const Notification = ({ noticeId, boardId, boardTitle, thumbnail, statusId, contact }: NotificationResp) => {
   const { handleDelete } = useNotification();
+
   return (
     <section className="bg-white mt-2 py-2 px-3 rounded-lg space-y-3">
       <article className="flex justify-between items-center border-b pt-2 pb-1">
-        <span>{NOTIFICATION_STATUS[status]} 알림</span>
+        <span>{NOTIFICATION_STATUS[statusId]} 알림</span>
         <i onClick={() => handleDelete(noticeId)}>
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -33,13 +26,13 @@ export const Notification = ({ noticeId, boardId, boardTitle, image, status, con
       <Link to={`/detail/${boardId}`} className="flex flex-col space-y-2">
         <article>
           <h1 className="text-lg font-bold">
-            {!status ? contact + NOTIFICATION_STATUS_MSG[status] : NOTIFICATION_STATUS_MSG[status]}
+            {!statusId ? contact + NOTIFICATION_STATUS_MSG[statusId] : NOTIFICATION_STATUS_MSG[statusId]}
           </h1>
-          {!status && <span className="text-sm">* 위 이메일로 연락해주세요.</span>}
+          {!statusId && <span className="text-sm">* 위 이메일로 연락해주세요.</span>}
         </article>
 
         <article className="flex items-center space-x-2 relative">
-          <img src={image} alt="상품 썸네일 이미지" className="w-10 h-10 rounded-md" />
+          <img src={thumbnail} alt="상품 썸네일 이미지" className="w-10 h-10 rounded-md" />
 
           <span className="text-sm">{getShortString(boardTitle, 20)}</span>
           <i>

--- a/client/src/components/NotificationPage/Notification/useNotification.ts
+++ b/client/src/components/NotificationPage/Notification/useNotification.ts
@@ -1,8 +1,0 @@
-export const useNotification = () => {
-  const handleDelete = (id) => {
-    // TODO: 삭제 로직 구현
-    console.log('delete');
-  };
-
-  return { handleDelete };
-};

--- a/client/src/components/_common/Header/MainHeader/MainHeader.tsx
+++ b/client/src/components/_common/Header/MainHeader/MainHeader.tsx
@@ -1,33 +1,23 @@
 import { Link } from 'react-router-dom';
-import { useEffect } from 'react';
 import { useRecoilValue } from 'recoil';
-import { loginStateAtom } from '../../../../atoms/user';
-import { useSSE } from '../../../../hooks/useSSE';
+import { userInfoAtom } from '../../../../atoms/user';
+import { useNotification } from '../../../../hooks/useNotification';
 
 export const MainHeader = ({ children }) => {
-  const loginState = useRecoilValue(loginStateAtom);
-  const { fetchSSE, eventSource } = useSSE();
+  const { notifications } = useNotification();
+  const { coin } = useRecoilValue(userInfoAtom);
 
-  // 로그인이 되어있는 경우에만 알림을 수신하도록 SSE를 연결합니다.
-  // TODO: 어떤 컴포넌트에서든 연결을 유지하도록 변경할 것
-  useEffect(() => {
-    if (loginState) {
-      fetchSSE();
-    }
-
-    return () => eventSource.current?.close();
-  }, [eventSource]);
-
+  // TODO: 로그인 상태에 따라 렌더링 내용 다르게 하기
   return (
     <header className="h-14 w-full sticky bg-main-brown py-3">
       <div className="h-full mx-3 text-white flex justify-between items-center">
         <h1 className="font-bold text-lg">{children}</h1>
         <div className="flex gap-3">
-          <span className="">10,000 coin</span>
+          <span className="">{coin.toLocaleString()} coin</span>
           <Link to="/notification">
             <>
               <div className="top-3 right-3 absolute w-3.5 h-3.5 rounded-full text-xs flex justify-center items-center bg-red-600">
-                3
+                {notifications?.length || 0}
               </div>
               <i>
                 <svg

--- a/client/src/components/_common/SSE/SSE.tsx
+++ b/client/src/components/_common/SSE/SSE.tsx
@@ -1,0 +1,23 @@
+import { useEffect } from 'react';
+import { useRecoilValue } from 'recoil';
+import { loginStateAtom } from '../../../atoms/user';
+import { useSSE } from '../../../hooks/useSSE';
+
+export const SSE = () => {
+  const loginState = useRecoilValue(loginStateAtom);
+  const { fetchSSE, eventSource } = useSSE();
+
+  // FIXME: 가끔 알림이 씹히는 경우 수정하기. 연결 불안정? 연결 오류?
+  // 로그인시 SSE 연결
+  useEffect(() => {
+    if (loginState) {
+      fetchSSE();
+      // TODO: 첫 마운트시 API 요청하여 쿼리 데이터 동기화
+      // TODO: 새로고침, 창 닫았다가 다시 열었을 때 쿼리 데이터 동기화
+    }
+
+    return () => eventSource.current?.close();
+  }, [eventSource, loginState]);
+
+  return <></>;
+};

--- a/client/src/constants/constants.ts
+++ b/client/src/constants/constants.ts
@@ -2,7 +2,7 @@ export const CATEGORIES = ['ALL', '디지털 / 가전', '가구 / 생활', '의�
 
 export const AUCTION_STATUS = ['진행중', '낙찰', '마감'];
 
-export const NOTIFICATION_STATUS = ['낙찰', '낙찰', '유찰', '상회 입찰', '마감 임박'];
+export const NOTIFICATION_STATUS = ['', '낙찰', '낙찰', '유찰', '상회 입찰', '마감 임박'];
 
 export const NOTIFICATION_STATUS_MSG = [
   '님이 낙찰되셨습니다.',
@@ -19,3 +19,5 @@ export const CATEGORIE_SORT_STATUS = ['마감 임박', 'TOP 입찰 횟수', 'TOP
 export const REG_EMAIL = /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i;
 export const REG_PASSWORD = /^(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-]).{8,}$/;
 export const REG_KOREA = /[ㄱ-ㅎㅏ-ㅣ가-힣]+/g;
+
+export const NOTIFICATION_KEY = 'notifications';

--- a/client/src/hooks/useNotification.ts
+++ b/client/src/hooks/useNotification.ts
@@ -1,0 +1,14 @@
+import { useQueryClient } from 'react-query';
+import { NOTIFICATION_KEY } from '../constants/constants';
+import { NotificationResp } from '../types/notice.type';
+
+export const useNotification = () => {
+  const queryClient = useQueryClient();
+  const notifications = queryClient.getQueryData(NOTIFICATION_KEY) as NotificationResp[];
+
+  const handleDelete = (noticeId: number) => {
+    // TODO: 알림 삭제기능 구현하기
+  };
+
+  return { notifications, handleDelete };
+};

--- a/client/src/hooks/useSSE.ts
+++ b/client/src/hooks/useSSE.ts
@@ -1,16 +1,21 @@
 import { EventSourcePolyfill, NativeEventSource } from 'event-source-polyfill';
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useRef } from 'react';
+import { useQueryClient } from 'react-query';
 import { useRecoilValue } from 'recoil';
 import { accessTokenAtom } from '../atoms/token';
+import { NOTIFICATION_KEY } from '../constants/constants';
+import { NotificationResp } from '../types/notice.type';
 
 export const useSSE = () => {
   const accessToken = useRecoilValue(accessTokenAtom);
   const eventSource = useRef<EventSourcePolyfill | EventSource>();
+  const queryClient = useQueryClient();
 
   // sse 연결 함수
   const fetchSSE = useCallback(() => {
     const EventSource = EventSourcePolyfill || NativeEventSource;
 
+    // 새로운 EventSource 연결
     eventSource.current = new EventSource(`${process.env.REACT_APP_URL}/subscribe`, {
       headers: {
         Authorization: accessToken,
@@ -18,17 +23,21 @@ export const useSSE = () => {
       heartbeatTimeout: 30000,
     });
 
+    // 메시지 수신시 캐시에 저장
     eventSource.current.onmessage = (event) => {
-      console.log(event.data);
+      queryClient.setQueryData(NOTIFICATION_KEY, (prevData: NotificationResp[] | null) => {
+        if (event.data[0] === 'E') console.log(event.data);
+
+        const eventData = event.data[0] === '{' ? JSON.parse(event.data) : null;
+        const newData = prevData ? [...prevData, eventData] : [eventData];
+        return eventData ? newData : prevData;
+      });
     };
 
     eventSource.current.onerror = (event) => {
-      console.error(event);
-      eventSource.current.close();
+      // console.error(event);
     };
   }, []);
-
-  // TODO: SSE 알림 수신시 알림 데이터 저장
 
   // 조건에 따라 sse 연결 함수를 실행하도록 fetchSSE 그리고 eventSource 객체를 리턴합니다.
   return { fetchSSE, eventSource };

--- a/client/src/pages/NoficationPage.tsx
+++ b/client/src/pages/NoficationPage.tsx
@@ -1,25 +1,27 @@
-import { useEffect } from 'react';
 import { TabBar } from '../components/_common/TabBar/TabBar';
 import { SubHeader } from '../components/_common/Header/SubHeader/SubHeader';
 import { Notification } from '../components/NotificationPage/Notification/Notification';
-import { notificationResp } from '../mock/notificationResp';
+import { useNotification } from '../hooks/useNotification';
 
 export const NotificationPage = () => {
+  const { notifications } = useNotification();
+  console.log(notifications);
   return (
     <main className="base-layout">
       <SubHeader>알림</SubHeader>
       <section className="content-layout">
-        {notificationResp.items.map((noti) => (
-          <Notification
-            noticeId={noti.noticeId}
-            boardId={noti.boardId}
-            boardTitle={noti.boardTitle}
-            image={noti.image}
-            status={noti.status}
-            contact={noti.contact}
-            key={noti.noticeId}
-          />
-        ))}
+        {notifications &&
+          notifications.map((noti) => (
+            <Notification
+              noticeId={noti.noticeId}
+              boardId={noti.boardId}
+              boardTitle={noti.boardTitle}
+              thumbnail={noti.thumbnail}
+              statusId={noti.statusId}
+              contact={noti.contact}
+              key={noti.noticeId}
+            />
+          ))}
       </section>
       <TabBar />
     </main>

--- a/client/src/types/notice.type.tsx
+++ b/client/src/types/notice.type.tsx
@@ -1,0 +1,9 @@
+export interface NotificationResp {
+  noticeId: number;
+  boardId: number;
+  boardTitle: string;
+  thumbnail: string;
+  statusId: number;
+  contact: string;
+  coin?: number; // 상회 입찰시에만 응답
+}


### PR DESCRIPTION
![daily-0302](https://user-images.githubusercontent.com/89173923/222384824-2903ce63-b908-4b35-abd5-f83bf8e6bf3f.gif)
* 리액트 쿼리를 사용해 SSE 알림 데이터를 수신하고 이를 화면에 렌더링합니다.

### 수정할 부분
* SSE 연결이 불안정한지? 가끔 알림이 제대로 수신되지 않는 경우가 있어 확인 필요합니다.
* 새로고침시 상태를 유지하지 않기 때문에 전체 데이터를 수신해서 등록하는 로직이 필요합니다. (API 개발중)
* 리액트 쿼리 부분을 수정해서 업데이트 될 때마다 자동으로 리렌더링 되도록 수정 필요합니다.
* 알림과 연관된 기타 다른 데이터 수정 필요(코인 업데이트 등), 알림 컴포넌트 내부 데이터 등...