### PR TITLE
알림 조회/삭제, 헤더 상태 변경, 기타 버그 수정

### DIFF
--- a/client/src/api/boardsAPI.ts
+++ b/client/src/api/boardsAPI.ts
@@ -20,5 +20,10 @@ export const productDetailAPI = {
 
   postBid: (path: string, newPrice: number) => httpClient.post(`${productDetailAPI.url}/${path}/bidding`, { newPrice }),
 
-  delete: (path: string) => httpClient.delete(`${productDetailAPI.url}/${path}`),
+  delete: (path: string, token: string) =>
+    httpClient.delete(`${productDetailAPI.url}/${path},`, {
+      headers: {
+        Authorization: token,
+      },
+    }),
 };

--- a/client/src/api/boardsAPI.ts
+++ b/client/src/api/boardsAPI.ts
@@ -1,6 +1,8 @@
 import { ProductDetailResp } from '../types/product.type';
 import { httpClient } from '../utils/httpClient';
 
+// TODO: 메서드 정의 방식 화살표 => 단축문법으로 변경
+// TODO: 인터셉터 기능 완성되면 option 객체 및 token 주입 제거하기
 export const productDetailAPI = {
   url: `/boards`,
 

--- a/client/src/api/noticesAPI.ts
+++ b/client/src/api/noticesAPI.ts
@@ -1,0 +1,31 @@
+import { httpClient } from '../utils/httpClient';
+import { NotificationResp } from '../types/notice.type';
+
+type NoticesResp = {
+  items: NotificationResp[];
+};
+
+export const noticesAPI = {
+  url: `/notices`,
+
+  async get(token: string) {
+    const option = {
+      headers: {
+        Authorization: token,
+      },
+    };
+
+    const res = await httpClient.get<NoticesResp>(this.url, option);
+    return res.data.items;
+  },
+
+  async delete(id: number, token: string) {
+    const res = await httpClient.delete(`${this.url}/${id}`, {
+      headers: {
+        Authorization: token,
+      },
+    });
+
+    return res.data;
+  },
+};

--- a/client/src/components/DetailPage/BidInformation/useBidInfoModal.ts
+++ b/client/src/components/DetailPage/BidInformation/useBidInfoModal.ts
@@ -39,14 +39,14 @@ export const useBidInfoModal = ({ bidValue, setBidValue, setValidationMsg, handl
 
   // 구매자가 입찰시 사용되는 핸들러
   const handleClickBid = async (currentPrice: number, sendBid: (price: number) => void) => {
-    if (+bidValue > +myCoin) {
+    const bidValuePer1000 = useCoinCalc(bidValue);
+    setBidValue(String(bidValuePer1000));
+
+    if (+bidValuePer1000 > +myCoin) {
       setValidationMsg('보유한 코인이 부족합니다.');
-    } else if (+bidValue <= +currentPrice) {
+    } else if (+bidValuePer1000 <= +currentPrice) {
       setValidationMsg('현재 경매가보다 높은 가격을 입력해주세요.');
     } else {
-      const bidValuePer1000 = useCoinCalc(bidValue);
-      setBidValue(String(bidValuePer1000));
-
       // eslint-disable-next-line no-restricted-globals, no-alert, no-lonely-if
       if (confirm(`${bidValuePer1000}coin으로 입찰 하시겠습니까?`)) {
         setValidationMsg('입찰하였습니다!');

--- a/client/src/components/DetailPage/BidInformation/useBidInformation.ts
+++ b/client/src/components/DetailPage/BidInformation/useBidInformation.ts
@@ -1,24 +1,25 @@
-import React, { SetStateAction } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 import { productDetailAPI } from '../../../api/boardsAPI';
-import { userInfoAtom } from '../../../atoms/user';
+import { accessTokenAtom } from '../../../atoms/token';
 
 export const useBidInformation = () => {
   const navigate = useNavigate();
+  const accessToken = useRecoilValue(accessTokenAtom);
 
   // 판매자가 재등록 및 삭제할 때 사용되는 핸들러
   const handleClickRePost = (boardId: string) => {
     // boardId로 재등록 요청된 게시글 데이터를 조회할 수 있음.
     navigate(`/postProduct?${boardId}`);
   };
+
   const handleDeleteProduct = async (boardId: string) => {
     try {
       if (
         // eslint-disable-next-line
         confirm('정말 삭제하시겠습니까?')
       ) {
-        await productDetailAPI.delete(boardId);
+        await productDetailAPI.delete(boardId, accessToken);
         navigate('/categoryProduct/0');
       }
     } catch (err) {

--- a/client/src/components/LoginPage/Login/Login.tsx
+++ b/client/src/components/LoginPage/Login/Login.tsx
@@ -40,7 +40,7 @@ export const Login = () => {
           setRefreshToken(res.refreshtoken);
           setUserInfo({
             memberId: Number(res.memberid),
-            coin: res.coin,
+            coin: Number(res.coin),
             email: res.email,
           });
           setLoginState(true);

--- a/client/src/components/NotificationPage/Notification/Notification.tsx
+++ b/client/src/components/NotificationPage/Notification/Notification.tsx
@@ -26,9 +26,9 @@ export const Notification = ({ noticeId, boardId, boardTitle, thumbnail, statusI
       <Link to={`/detail/${boardId}`} className="flex flex-col space-y-2">
         <article>
           <h1 className="text-lg font-bold">
-            {!statusId ? contact + NOTIFICATION_STATUS_MSG[statusId] : NOTIFICATION_STATUS_MSG[statusId]}
+            {statusId === 1 ? contact + NOTIFICATION_STATUS_MSG[statusId] : NOTIFICATION_STATUS_MSG[statusId]}
           </h1>
-          {!statusId && <span className="text-sm">* 위 이메일로 연락해주세요.</span>}
+          {statusId === 1 && <span className="text-sm">* 위 이메일로 연락해주세요.</span>}
         </article>
 
         <article className="flex items-center space-x-2 relative">

--- a/client/src/components/NotificationPage/Notification/Notification.tsx
+++ b/client/src/components/NotificationPage/Notification/Notification.tsx
@@ -18,7 +18,7 @@ export const Notification = ({ noticeId, boardId, boardTitle, thumbnail, statusI
             viewBox="0 0 24 24"
             strokeWidth={1.5}
             stroke="currentColor"
-            className="w-5 h-5">
+            className="w-5 h-5 cursor-pointer">
             <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
           </svg>
         </i>

--- a/client/src/components/_common/Header/MainHeader/MainHeader.tsx
+++ b/client/src/components/_common/Header/MainHeader/MainHeader.tsx
@@ -1,42 +1,62 @@
 import { Link } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
-import { userInfoAtom } from '../../../../atoms/user';
+import { loginStateAtom, userInfoAtom } from '../../../../atoms/user';
 import { useNotification } from '../../../../hooks/useNotification';
 
 export const MainHeader = ({ children }) => {
   const { notifications } = useNotification();
   const { coin } = useRecoilValue(userInfoAtom);
+  const loginState = useRecoilValue(loginStateAtom);
 
-  // TODO: 로그인 상태에 따라 렌더링 내용 다르게 하기
   return (
     <header className="h-14 w-full sticky bg-main-brown py-3">
       <div className="h-full mx-3 text-white flex justify-between items-center">
         <h1 className="font-bold text-lg">{children}</h1>
-        <div className="flex gap-3">
-          <span className="">{coin.toLocaleString()} coin</span>
-          <Link to="/notification">
-            <>
-              <div className="top-3 right-3 absolute w-3.5 h-3.5 rounded-full text-xs flex justify-center items-center bg-red-600">
-                {notifications?.length || 0}
-              </div>
-              <i>
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  strokeWidth="1.5"
-                  stroke="currentColor"
-                  className="w-6 h-6">
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    d="M14.857 17.082a23.848 23.848 0 005.454-1.31A8.967 8.967 0 0118 9.75v-.7V9A6 6 0 006 9v.75a8.967 8.967 0 01-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 01-5.714 0m5.714 0a3 3 0 11-5.714 0"
-                  />
-                </svg>
-              </i>
-            </>
+        {loginState ? (
+          <div className="flex gap-3">
+            <span className="">{coin.toLocaleString()} coin</span>
+            <Link to="/notification">
+              <>
+                <div className="top-3 right-3 absolute w-3.5 h-3.5 rounded-full text-xs flex justify-center items-center bg-red-600">
+                  {notifications?.length || 0}
+                </div>
+                <i>
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    strokeWidth="1.5"
+                    stroke="currentColor"
+                    className="w-6 h-6">
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M14.857 17.082a23.848 23.848 0 005.454-1.31A8.967 8.967 0 0118 9.75v-.7V9A6 6 0 006 9v.75a8.967 8.967 0 01-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 01-5.714 0m5.714 0a3 3 0 11-5.714 0"
+                    />
+                  </svg>
+                </i>
+              </>
+            </Link>
+          </div>
+        ) : (
+          <Link to="/search">
+            <i>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={1.5}
+                stroke="currentColor"
+                className="w-6 h-6">
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
+                />
+              </svg>
+            </i>
           </Link>
-        </div>
+        )}
       </div>
     </header>
   );

--- a/client/src/components/_common/SSE/SSE.tsx
+++ b/client/src/components/_common/SSE/SSE.tsx
@@ -7,13 +7,10 @@ export const SSE = () => {
   const loginState = useRecoilValue(loginStateAtom);
   const { fetchSSE, eventSource } = useSSE();
 
-  // FIXME: 가끔 알림이 씹히는 경우 수정하기. 연결 불안정? 연결 오류?
   // 로그인시 SSE 연결
   useEffect(() => {
     if (loginState) {
       fetchSSE();
-      // TODO: 첫 마운트시 API 요청하여 쿼리 데이터 동기화
-      // TODO: 새로고침, 창 닫았다가 다시 열었을 때 쿼리 데이터 동기화
     }
 
     return () => eventSource.current?.close();

--- a/client/src/constants/constants.ts
+++ b/client/src/constants/constants.ts
@@ -5,6 +5,7 @@ export const AUCTION_STATUS = ['진행중', '낙찰', '마감'];
 export const NOTIFICATION_STATUS = ['', '낙찰', '낙찰', '유찰', '상회 입찰', '마감 임박'];
 
 export const NOTIFICATION_STATUS_MSG = [
+  '',
   '님이 낙찰되셨습니다.',
   '입찰에 성공하였습니다.',
   '해당 물품이 유찰되었습니다.',

--- a/client/src/hooks/useSSE.ts
+++ b/client/src/hooks/useSSE.ts
@@ -30,6 +30,7 @@ export const useSSE = () => {
 
         const eventData = event.data[0] === '{' ? JSON.parse(event.data) : null;
         const newData = prevData ? [...prevData, eventData] : [eventData];
+
         return eventData ? newData : prevData;
       });
     };

--- a/client/src/hooks/useSSE.ts
+++ b/client/src/hooks/useSSE.ts
@@ -29,15 +29,17 @@ export const useSSE = () => {
         if (event.data[0] === 'E') console.log(event.data);
 
         const eventData = event.data[0] === '{' ? JSON.parse(event.data) : null;
-        const newData = prevData ? [...prevData, eventData] : [eventData];
+
+        const newData =
+          prevData && eventData
+            ? [...prevData.filter((data) => data.noticeId !== eventData?.noticeId), eventData]
+            : [eventData];
 
         return eventData ? newData : prevData;
       });
     };
 
-    eventSource.current.onerror = (event) => {
-      // console.error(event);
-    };
+    eventSource.current.onerror = (event) => {};
   }, []);
 
   // 조건에 따라 sse 연결 함수를 실행하도록 fetchSSE 그리고 eventSource 객체를 리턴합니다.

--- a/client/src/hooks/useSSE.ts
+++ b/client/src/hooks/useSSE.ts
@@ -1,8 +1,9 @@
 import { EventSourcePolyfill, NativeEventSource } from 'event-source-polyfill';
 import { useCallback, useRef } from 'react';
 import { useQueryClient } from 'react-query';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { accessTokenAtom } from '../atoms/token';
+import { userInfoAtom } from '../atoms/user';
 import { NOTIFICATION_KEY } from '../constants/constants';
 import { NotificationResp } from '../types/notice.type';
 
@@ -10,6 +11,7 @@ export const useSSE = () => {
   const accessToken = useRecoilValue(accessTokenAtom);
   const eventSource = useRef<EventSourcePolyfill | EventSource>();
   const queryClient = useQueryClient();
+  const setUserInfo = useSetRecoilState(userInfoAtom);
 
   // sse 연결 함수
   const fetchSSE = useCallback(() => {
@@ -25,11 +27,12 @@ export const useSSE = () => {
 
     // 메시지 수신시 캐시에 저장
     eventSource.current.onmessage = (event) => {
+      if (event.data[0] === 'E') console.log(event.data);
+
+      const eventData = event.data[0] === '{' ? JSON.parse(event.data) : null;
+
+      // 알림 데이터 업데이트
       queryClient.setQueryData(NOTIFICATION_KEY, (prevData: NotificationResp[] | null) => {
-        if (event.data[0] === 'E') console.log(event.data);
-
-        const eventData = event.data[0] === '{' ? JSON.parse(event.data) : null;
-
         const newData =
           prevData && eventData
             ? [...prevData.filter((data) => data.noticeId !== eventData?.noticeId), eventData]
@@ -37,6 +40,13 @@ export const useSSE = () => {
 
         return eventData ? newData : prevData;
       });
+
+      // 알림 데이터에 coin이 있으면, coin 상태를 업데이트
+      if (eventData && eventData.coin) {
+        setUserInfo((prev) => {
+          return { ...prev, ...{ coin: eventData.coin } };
+        });
+      }
     };
 
     eventSource.current.onerror = (event) => {};

--- a/client/src/pages/NoficationPage.tsx
+++ b/client/src/pages/NoficationPage.tsx
@@ -5,7 +5,6 @@ import { useNotification } from '../hooks/useNotification';
 
 export const NotificationPage = () => {
   const { notifications } = useNotification();
-  console.log(notifications);
   return (
     <main className="base-layout">
       <SubHeader>알림</SubHeader>


### PR DESCRIPTION
![daily-0303](https://user-images.githubusercontent.com/89173923/222672798-4c85abad-8b64-45f2-8b42-de333d0246eb.gif)
![image](https://user-images.githubusercontent.com/89173923/222673320-3de073d0-5c85-479a-9e5b-0f96ecd6457c.png)


* 로그인, 새로고침시 전체 알림 데이터를 api로 요청하여 조회합니다.
* 이후 SSE 연결을 통해 알림을 실시간으로 수신하고 업데이트합니다.
* 알림 삭제 기능 구현하였습니다.
* 상회입찰 알림시 coin 데이터 포함된 경우, 현재 coin 을 업데이트합니다. 
* 로그아웃 상태일 경우 헤더에 검색 아이콘 노출됩니다.
* 입찰시 현재가를 1000원 단위로 절삭된 가격을 기준으로 비교하도록 수정하였습니다.
* 게시글 삭제시 토큰 전송하도록 수정하였습니다.

### NOTE
* 간헐적으로 SSE 연결에서 500에러가 발생해서 연결이 제대로 이루어지지 않는 경우가 있습니다.
* 이로 인해서 알림이 가끔 수신되지 않는 현상이 있습니다. ㅜ